### PR TITLE
Redirect site traffic to MisterJK blog

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,5 +8,5 @@
 
 [[redirects]]
   from = "/*"
-  to = "/index.html"
-  status = 200
+  to = "https://misterjk.com/blog"
+  status = 301


### PR DESCRIPTION
## Summary
- update the Netlify redirect rule to send all requests to https://misterjk.com/blog with a permanent redirect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3befedbc832e85387a0eb929c8e7