### PR TITLE
Add Discography Search page with incremental results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Footer from './components/Footer';
 // Import all song components
 import TSTT from './pages/page/TSTT.jsx';
 import TNG from './pages/page/TNG.jsx';
+import DiscographySearch from './pages/DiscographySearch.jsx';
 
 function App() {
   return (
@@ -17,6 +18,7 @@ function App() {
         <Route path="/" element={<ArticlesHomePage />} />
         <Route path="/page/tng/" element={<TNG />} />
         <Route path="/page/tstt/" element={<TSTT />} />
+        <Route path="/discography/" element={<DiscographySearch />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/src/components/DiscographySearcher.jsx
+++ b/src/components/DiscographySearcher.jsx
@@ -1,0 +1,368 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowUpRight, Filter, RefreshCw, Search, X } from 'lucide-react';
+import { discographyEntries } from '../data/discography';
+
+const INITIAL_BATCH = 5;
+
+const formatReleaseLabel = (entry) => {
+  if (!entry.releaseDate) {
+    return entry.isUpcoming ? 'Coming soon' : 'Release date TBA';
+  }
+
+  const date = new Date(entry.releaseDate);
+  if (Number.isNaN(date.getTime())) {
+    return entry.releaseDate;
+  }
+
+  if (entry.isUpcoming) {
+    return `Coming ${date.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })}`;
+  }
+
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric'
+  });
+};
+
+const normalizeText = (value) => value?.toString().toLowerCase() ?? '';
+
+export default function DiscographySearcher() {
+  const [query, setQuery] = useState('');
+  const [selectedTypes, setSelectedTypes] = useState([]);
+  const [selectedYear, setSelectedYear] = useState('all');
+  const [sortOrder, setSortOrder] = useState('newest');
+  const [visibleCount, setVisibleCount] = useState(INITIAL_BATCH);
+
+  const scrollContainerRef = useRef(null);
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const typeOptions = useMemo(() => {
+    return Array.from(new Set(discographyEntries.map((entry) => entry.type))).sort();
+  }, []);
+
+  const yearOptions = useMemo(() => {
+    const years = new Set();
+    discographyEntries.forEach((entry) => {
+      if (entry.year) {
+        years.add(entry.year);
+      }
+    });
+    return Array.from(years).sort((a, b) => b - a);
+  }, []);
+
+  const filteredResults = useMemo(() => {
+    const results = discographyEntries.filter((entry) => {
+      const matchesYear =
+        selectedYear === 'all' || (entry.year && entry.year.toString() === selectedYear);
+
+      const matchesType =
+        selectedTypes.length === 0 || selectedTypes.includes(entry.type);
+
+      const combined = [
+        entry.title,
+        entry.summary,
+        entry.type,
+        ...(entry.artists ?? []),
+        ...(entry.tags ?? []),
+        ...(entry.highlightTracks ?? []),
+        entry.notes ?? ''
+      ]
+        .map(normalizeText)
+        .join(' ');
+
+      const matchesQuery = normalizedQuery === '' || combined.includes(normalizedQuery);
+
+      return matchesYear && matchesType && matchesQuery;
+    });
+
+    results.sort((a, b) => {
+      const aDate = new Date(a.releaseDate).getTime();
+      const bDate = new Date(b.releaseDate).getTime();
+
+      if (Number.isNaN(aDate) && Number.isNaN(bDate)) return 0;
+      if (Number.isNaN(aDate)) return 1;
+      if (Number.isNaN(bDate)) return -1;
+
+      return sortOrder === 'newest' ? bDate - aDate : aDate - bDate;
+    });
+
+    return results;
+  }, [normalizedQuery, selectedTypes, selectedYear, sortOrder]);
+
+  const visibleItems = useMemo(
+    () => filteredResults.slice(0, visibleCount),
+    [filteredResults, visibleCount]
+  );
+
+  const shouldEnableScroll = visibleCount > INITIAL_BATCH && visibleItems.length > INITIAL_BATCH;
+  const resultsMessage = useMemo(() => {
+    if (filteredResults.length === 0) {
+      return 'No releases match your filters yet.';
+    }
+
+    if (visibleItems.length === filteredResults.length) {
+      return `Showing all ${filteredResults.length} releases.`;
+    }
+
+    return `Showing ${visibleItems.length} of ${filteredResults.length} releases.`;
+  }, [filteredResults.length, visibleItems.length]);
+
+  useEffect(() => {
+    setVisibleCount(INITIAL_BATCH);
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = 0;
+    }
+  }, [normalizedQuery, selectedTypes, selectedYear, sortOrder]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || !shouldEnableScroll) return undefined;
+
+    const handleWheel = (event) => {
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const atTop = scrollTop <= 0;
+      const atBottom = scrollTop + clientHeight >= scrollHeight;
+
+      if ((atTop && event.deltaY < 0) || (atBottom && event.deltaY > 0)) {
+        event.preventDefault();
+      }
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => container.removeEventListener('wheel', handleWheel);
+  }, [shouldEnableScroll, visibleItems.length]);
+
+  const toggleType = (type) => {
+    setSelectedTypes((prev) =>
+      prev.includes(type) ? prev.filter((value) => value !== type) : [...prev, type]
+    );
+  };
+
+  const resetFilters = () => {
+    setQuery('');
+    setSelectedTypes([]);
+    setSelectedYear('all');
+    setSortOrder('newest');
+  };
+
+  return (
+    <section className="mt-8">
+      <div className="rounded-2xl border border-neutral-200 bg-white/90 shadow-[0_12px_30px_rgba(15,23,42,0.08)] p-6 md:p-8">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-neutral-400" aria-hidden="true" />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search songs, releases, or keywords..."
+              className="w-full rounded-xl border border-neutral-300 bg-gradient-to-b from-white to-neutral-50 px-10 py-3 text-sm text-neutral-800 shadow-[inset_0_1px_0_rgba(255,255,255,0.85),0_6px_16px_rgba(15,23,42,0.1)] focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                className="absolute right-3 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full border border-neutral-300 bg-white text-neutral-500 transition hover:text-neutral-700"
+                aria-label="Clear search"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <label htmlFor="discography-sort" className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              Sort by
+            </label>
+            <select
+              id="discography-sort"
+              value={sortOrder}
+              onChange={(event) => setSortOrder(event.target.value)}
+              className="rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+            >
+              <option value="newest">Newest first</option>
+              <option value="oldest">Oldest first</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-6 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="flex-1">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              <Filter className="h-4 w-4" />
+              Filter by type
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {typeOptions.map((type) => {
+                const isActive = selectedTypes.includes(type);
+                return (
+                  <button
+                    key={type}
+                    type="button"
+                    onClick={() => toggleType(type)}
+                    className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+                      isActive
+                        ? 'border-blue-500 bg-blue-600 text-white shadow-[0_10px_20px_rgba(37,99,235,0.35)]'
+                        : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-400'
+                    }`}
+                  >
+                    {type}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <label htmlFor="discography-year" className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              Year
+            </label>
+            <select
+              id="discography-year"
+              value={selectedYear}
+              onChange={(event) => setSelectedYear(event.target.value)}
+              className="rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm font-medium text-neutral-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/40"
+            >
+              <option value="all">All years</option>
+              {yearOptions.map((year) => (
+                <option key={year} value={year}>
+                  {year}
+                </option>
+              ))}
+            </select>
+
+            {(selectedTypes.length > 0 || selectedYear !== 'all' || query) && (
+              <button
+                type="button"
+                onClick={resetFilters}
+                className="inline-flex items-center gap-1 rounded-full border border-neutral-300 bg-white px-3 py-1.5 text-xs font-semibold text-neutral-600 transition hover:border-neutral-400 hover:text-neutral-800"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Reset
+              </button>
+            )}
+          </div>
+        </div>
+
+        <p className="mt-6 text-sm text-neutral-600" aria-live="polite">
+          {resultsMessage}
+        </p>
+
+        <div
+          ref={scrollContainerRef}
+          className={`mt-4 space-y-4 ${
+            shouldEnableScroll
+              ? 'max-h-[60vh] overflow-y-auto overscroll-contain pr-2 custom-scrollbar'
+              : ''
+          }`}
+          aria-live="polite"
+        >
+          {visibleItems.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-neutral-300 bg-neutral-50/70 px-6 py-12 text-center">
+              <p className="text-lg font-semibold text-neutral-700">No releases found</p>
+              <p className="mt-2 text-sm text-neutral-500">
+                Try a different keyword or remove a filter to widen the search.
+              </p>
+            </div>
+          ) : (
+            visibleItems.map((entry) => (
+              <article
+                key={entry.id}
+                className="group rounded-xl border border-neutral-200 bg-gradient-to-b from-white to-neutral-50 p-5 shadow-[0_10px_24px_rgba(15,23,42,0.08)] transition hover:-translate-y-0.5 hover:shadow-[0_18px_36px_rgba(15,23,42,0.12)]"
+              >
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div className="flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-xl font-bold text-neutral-900">{entry.title}</h3>
+                      <span className="rounded-full border border-neutral-300 bg-white px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-neutral-600">
+                        {entry.type}
+                      </span>
+                      {entry.isUpcoming && (
+                        <span className="rounded-full border border-amber-300 bg-amber-100 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-700">
+                          Upcoming
+                        </span>
+                      )}
+                    </div>
+
+                    <p className="mt-1 text-sm text-neutral-500">
+                      {formatReleaseLabel(entry)}
+                      {entry.runtime ? ` · ${entry.runtime}` : ''}
+                    </p>
+
+                    {entry.artists?.length ? (
+                      <p className="mt-2 text-sm text-neutral-600">
+                        <span className="font-semibold text-neutral-700">Artists:</span> {entry.artists.join(', ')}
+                      </p>
+                    ) : null}
+
+                    <p className="mt-3 text-sm leading-relaxed text-neutral-700">
+                      {entry.summary}
+                    </p>
+
+                    {entry.highlightTracks?.length ? (
+                      <p className="mt-3 text-sm text-neutral-600">
+                        <span className="font-semibold text-neutral-700">Highlights:</span> {entry.highlightTracks.join(', ')}
+                      </p>
+                    ) : null}
+
+                    {entry.notes ? (
+                      <p className="mt-3 text-xs italic text-neutral-500">{entry.notes}</p>
+                    ) : null}
+
+                    {entry.tags?.length ? (
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {entry.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded-full border border-neutral-200 bg-neutral-100 px-2.5 py-1 text-xs font-semibold text-neutral-700"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+
+                  {entry.links?.length ? (
+                    <div className="md:w-48">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                        Explore
+                      </span>
+                      <div className="mt-2 flex flex-col gap-2">
+                        {entry.links.map((link) => (
+                          <a
+                            key={link.label}
+                            href={link.url}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center justify-between rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm font-semibold text-blue-600 transition hover:border-blue-400 hover:text-blue-700"
+                          >
+                            {link.label}
+                            <ArrowUpRight className="h-4 w-4" />
+                          </a>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+              </article>
+            ))
+          )}
+        </div>
+
+        {visibleCount < filteredResults.length && (
+          <div className="mt-6 flex justify-center">
+            <button
+              type="button"
+              onClick={() => setVisibleCount((prev) => Math.min(prev + INITIAL_BATCH, filteredResults.length))}
+              className="rounded-full border border-neutral-300 bg-white px-5 py-2.5 text-sm font-semibold text-neutral-700 shadow-[0_8px_18px_rgba(15,23,42,0.1)] transition hover:-translate-y-0.5 hover:border-neutral-400"
+            >
+              Show more results
+            </button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/data/discography.js
+++ b/src/data/discography.js
@@ -1,0 +1,238 @@
+export const discographyEntries = [
+  {
+    id: 'tng-diamond',
+    title: 'The Nice Girls (Diamond Edition)',
+    type: 'Album',
+    releaseDate: '2025-08-20',
+    year: 2025,
+    summary:
+      "Expanded edition of The Nice Girls featuring remastered fan favourites, new interludes, and commentary woven from the band's long-distance sessions.",
+    artists: ['The Nice Girls'],
+    tags: ['Album', 'The Nice Girls', 'Diamond Edition'],
+    highlightTracks: ["Sharin' Location", 'Girl Down', 'Inside Voice'],
+    notes: 'Includes the full track-by-track articles published on the blog.',
+    runtime: '52:48',
+    links: [
+      { label: 'Discover', url: 'https://misterjk.com/discover' },
+      { label: 'Lyrics', url: 'https://lyrics.misterjk.com' }
+    ]
+  },
+  {
+    id: 'tng-standard',
+    title: 'The Nice Girls',
+    type: 'Album',
+    releaseDate: '2024-11-01',
+    year: 2024,
+    summary:
+      'The original release that introduced the project\'s neon-pop storytelling, alternating vocals between Danica, Georgia, Jasmine, and MRJK.',
+    artists: ['The Nice Girls'],
+    tags: ['Album', 'The Nice Girls'],
+    highlightTracks: ['Return Policy', "GIRLSGIRLSGIRLS", 'You Can\'t Top This'],
+    runtime: '45:06',
+    links: [
+      { label: 'Discover', url: 'https://misterjk.com/discover' }
+    ]
+  },
+  {
+    id: 'sweet-tea-tragedies',
+    title: 'The Sweet Tea Tragedies',
+    type: 'EP',
+    releaseDate: '2025-09-19',
+    year: 2025,
+    summary:
+      'Georgia Wixen\'s country-tinged confessional EP that chronicles recovery, rage, and the rebuild after divorce.',
+    artists: ['Georgia Wixen'],
+    tags: ['EP', 'Georgia Wixen'],
+    highlightTracks: ['Y\'all Can Wait', 'Cry Me a Realtor', 'In Contempt'],
+    notes: 'Companion essays and audio commentary are available on the blog.',
+    runtime: '28:14',
+    links: [
+      { label: 'Prelude Audio', url: '/georgia_wixen_prelude_tstt.mp3' }
+    ]
+  },
+  {
+    id: 'santas-on-pto',
+    title: "Santa's on PTO (feat. Harley Towers)",
+    type: 'Single',
+    releaseDate: '2024-12-20',
+    year: 2024,
+    summary:
+      'Playful holiday-adjacent single that marked Harley Towers\' first collaboration with MRJK.',
+    artists: ['MRJK', 'Harley Towers'],
+    tags: ['Single', 'Collaboration', 'Holiday'],
+    highlightTracks: ["Santa's on PTO"],
+    runtime: '3:41',
+    links: [
+      { label: 'Blog Feature', url: 'https://blog.misterjk.com/' }
+    ]
+  },
+  {
+    id: 'sharin-location',
+    title: "Sharin' Location",
+    type: 'Single',
+    releaseDate: '2024-07-12',
+    year: 2024,
+    summary:
+      'Second track written for The Nice Girls, capturing the anxious humour of keeping someone\'s location long after the breakup.',
+    artists: ['The Nice Girls'],
+    tags: ['Single', 'The Nice Girls', 'Pop'],
+    highlightTracks: ["Sharin' Location"],
+    runtime: '3:58'
+  },
+  {
+    id: 'return-policy',
+    title: 'Return Policy',
+    type: 'Single',
+    releaseDate: '2025-02-14',
+    year: 2025,
+    summary:
+      'A fan-favourite breakup anthem comparing heartbreak to a department store return counter.',
+    artists: ['The Nice Girls'],
+    tags: ['Single', 'The Nice Girls'],
+    highlightTracks: ['Return Policy'],
+    runtime: '3:36'
+  },
+  {
+    id: 'girl-down',
+    title: 'Girl Down',
+    type: 'Single',
+    releaseDate: '2024-09-13',
+    year: 2024,
+    summary:
+      'Theatrical pop tragedy that spins heartbreak into a televised disaster scene.',
+    artists: ['The Nice Girls'],
+    tags: ['Single', 'The Nice Girls'],
+    highlightTracks: ['Girl Down'],
+    runtime: '3:49'
+  },
+  {
+    id: 'you-cant-top-this',
+    title: "You Can't Top This",
+    type: 'Single',
+    releaseDate: '2024-10-05',
+    year: 2024,
+    summary:
+      'Cocky, wink-filled anthem that became a live crowd chant and accidental lesbian anthem.',
+    artists: ['The Nice Girls'],
+    tags: ['Single', 'The Nice Girls'],
+    highlightTracks: ["You Can't Top This"],
+    runtime: '3:32'
+  },
+  {
+    id: 'inside-voice',
+    title: 'Inside Voice',
+    type: 'Single',
+    releaseDate: '2024-11-22',
+    year: 2024,
+    summary:
+      'Georgia Wixen turns silence into a howl, confronting violence with unflinching vocals.',
+    artists: ['The Nice Girls', 'Georgia Wixen'],
+    tags: ['Single', 'The Nice Girls', 'Georgia Wixen'],
+    highlightTracks: ['Inside Voice'],
+    runtime: '4:05'
+  },
+  {
+    id: 'yall-can-wait',
+    title: "Y'all Can Wait",
+    type: 'Single',
+    releaseDate: '2025-03-01',
+    year: 2025,
+    summary:
+      'A promise to slow down recovery and stop apologising for healing on your own schedule.',
+    artists: ['Georgia Wixen'],
+    tags: ['Single', 'Georgia Wixen'],
+    highlightTracks: ["Y'all Can Wait"],
+    runtime: '3:27'
+  },
+  {
+    id: 'cry-me-a-realtor',
+    title: 'Cry Me a Realtor',
+    type: 'Single',
+    releaseDate: '2025-04-05',
+    year: 2025,
+    summary:
+      'A biting divorce track that turns a cheating scandal into campy real-estate revenge.',
+    artists: ['Georgia Wixen'],
+    tags: ['Single', 'Georgia Wixen'],
+    highlightTracks: ['Cry Me a Realtor'],
+    runtime: '3:21'
+  },
+  {
+    id: 'in-contempt',
+    title: 'In Contempt',
+    type: 'Single',
+    releaseDate: '2025-05-01',
+    year: 2025,
+    summary:
+      'Courtroom-metaphor revenge anthem delivering the final ruling on a toxic marriage.',
+    artists: ['Georgia Wixen'],
+    tags: ['Single', 'Georgia Wixen'],
+    highlightTracks: ['In Contempt'],
+    runtime: '3:44'
+  },
+  {
+    id: 'i-do-i-dont',
+    title: "I Do (I Don't)",
+    type: 'Single',
+    releaseDate: '2025-06-14',
+    year: 2025,
+    summary:
+      'Reimagines the wedding aisle as a chance to reclaim autonomy and slam the door on regret.',
+    artists: ['Georgia Wixen'],
+    tags: ['Single', 'Georgia Wixen'],
+    highlightTracks: ["I Do (I Don't)"],
+    runtime: '3:38'
+  },
+  {
+    id: 'live-lounge',
+    title: 'The Nice Girls Live Lounge',
+    type: 'Live',
+    releaseDate: '2025-01-15',
+    year: 2025,
+    summary:
+      'Intimate live session capturing stripped-back versions of fan favourites with rotating vocal leads.',
+    artists: ['The Nice Girls'],
+    tags: ['Live', 'The Nice Girls'],
+    highlightTracks: ['Return Policy (Live)', "Sharin' Location (Live)"]
+  },
+  {
+    id: 'able-bagels-demo',
+    title: 'Able Bagels (Demo)',
+    type: 'Demo',
+    releaseDate: '2024-05-02',
+    year: 2024,
+    summary:
+      'Inside joke turned songwriting exercise that set the tone for the group\'s collaborative chaos.',
+    artists: ['Georgia Wixen', 'Jasmine Reyes'],
+    tags: ['Demo', 'The Nice Girls'],
+    highlightTracks: ['Able Bagels'],
+    notes: 'Shared privately with early supporters before morphing into the final Sharin\' Location lyrics.'
+  },
+  {
+    id: 'sweet-tea-tragedies-expanded',
+    title: 'The Sweet Tea Tragedies: Expanded Notes',
+    type: 'Compilation',
+    releaseDate: '2025-10-10',
+    year: 2025,
+    summary:
+      'Collects essays, spoken-word interludes, and alternate takes from the EP into a narrative mixtape.',
+    artists: ['Georgia Wixen'],
+    tags: ['Compilation', 'Georgia Wixen'],
+    highlightTracks: ['Prelude (Spoken)', 'I Sat With That (Acoustic)'],
+    notes: 'Pairs best with the written blog series for context.'
+  },
+  {
+    id: 'nice-girls-next-era',
+    title: 'The Nice Girls: Next Era',
+    type: 'Album',
+    releaseDate: '2026-04-18',
+    year: 2026,
+    summary:
+      'Work-in-progress follow up teasing heavier guitars, bilingual hooks, and a looser concept structure.',
+    artists: ['The Nice Girls'],
+    tags: ['Album', 'The Nice Girls', 'Upcoming'],
+    highlightTracks: ['Teaser: Static on the Hotline'],
+    notes: 'Currently in writing sessions across Austin, Dallas, Murfreesboro, and Wismar.',
+    isUpcoming: true
+  }
+];

--- a/src/index.css
+++ b/src/index.css
@@ -919,3 +919,28 @@ html.theme-taupe .skip-icon {
   color: #3f2f23 !important;
   fill: #3f2f23 !important;
 }
+
+/* Custom scrollbars for Discography Searcher */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(148, 163, 184, 0.7) transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.75);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(100, 116, 139, 0.85);
+}

--- a/src/pages/ArticlesHomePage.jsx
+++ b/src/pages/ArticlesHomePage.jsx
@@ -7,8 +7,17 @@ import NoiseBackground from "../components/NoiseBackground";
 export default function ArticlesBlogsPage() {
   const blogSections = [
     {
-      title: 'The Sweet Tea Tragedies',
+      title: 'Discography Searcher',
       isNew: true,
+      description: 'Instantly search and filter the entire MRJK discography.',
+      path: '/discography/',
+      cover: 'https://misterjk.com/site-assets/site_logo.png',
+      alt: 'Discography search interface',
+      comingSoon: false
+    },
+    {
+      title: 'The Sweet Tea Tragedies',
+      isNew: false,
       description: 'Articles and insights about Georgia Wixen\'s upcoming album',
       path: '/page/tstt/',
       cover: 'https://misterjk.com/site-assets/images/maxres/gather/format=jpg&name=3000x3000/GW_12012_FINAL_CORRECTED.jpg',

--- a/src/pages/DiscographySearch.jsx
+++ b/src/pages/DiscographySearch.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Navigation from '../components/Navigation';
+import NoiseBackground from '../components/NoiseBackground';
+import Footer from '../components/Footer';
+import DiscographySearcher from '../components/DiscographySearcher';
+
+export default function DiscographySearch() {
+  return (
+    <div className="min-h-screen relative overflow-hidden">
+      <NoiseBackground />
+      <Navigation />
+
+      <main className="relative z-10 min-h-screen pt-32 pb-24 px-4">
+        <div className="w-full max-w-5xl mx-auto">
+          <div className="rounded-2xl border border-neutral-300 bg-gradient-to-b from-white to-neutral-100 shadow-[0_16px_40px_rgba(15,23,42,0.15)] ring-1 ring-black/5 p-6 md:p-10">
+            <header className="text-center mb-8">
+              <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-neutral-800 drop-shadow-sm mb-4">
+                Discography Searcher
+              </h1>
+              <p className="text-lg md:text-xl text-neutral-600 max-w-2xl mx-auto leading-relaxed">
+                Instantly filter across albums, singles, live recordings, and upcoming projects from The Nice Girls universe. Use the search to jump straight to a song or toggle filters to explore by era.
+              </p>
+            </header>
+
+            <DiscographySearcher />
+          </div>
+          <div className="mt-12">
+            <Footer />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable DiscographySearcher component with instant filtering, batching, and scroll containment for results
- seed the searcher with curated discography metadata and expose a dedicated /discography/ page
- surface the new tool from the articles landing page and polish the scrollbar styling for the results panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de43252544832eb1ede9d9087d0844